### PR TITLE
Allow override precision form option

### DIFF
--- a/Repository/Resource/Type/NumberType.php
+++ b/Repository/Resource/Type/NumberType.php
@@ -32,10 +32,10 @@ class NumberType extends AbstractType
         $options = parent::buildFormOptions();
 
         $options = array_merge(
-            $options,
             array(
                 'precision' => 4
-            )
+            ),
+            $options
         );
 
         return $options;

--- a/spec/FSi/Bundle/ResourceRepositoryBundle/Repository/Resource/Type/NumberTypeSpec.php
+++ b/spec/FSi/Bundle/ResourceRepositoryBundle/Repository/Resource/Type/NumberTypeSpec.php
@@ -90,7 +90,7 @@ class NumberTypeSpec extends ObjectBehavior
             'label' => false,
             'required' => false,
             'precision' => 8
-        ))->shouldBeCalled();
+        ))->willReturn($form);
 
         $this->getFormBuilder($factory)->shouldReturnAnInstanceOf('Symfony\Component\Form\FormBuilder');
     }


### PR DESCRIPTION
There is no easy way to override `precision` form option from Number resource type.
