### PR TITLE
Changed form type used by CKEditor resource type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - php: hhvm
 
 before_script:
+  - phpenv config-rm xdebug.ini
+  # Avoid issues on composer update
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer update --prefer-source ${COMPOSER_FLAGS}
 
 script: ./bin/phpspec run -f pretty

--- a/Repository/Resource/Type/CKEditorType.php
+++ b/Repository/Resource/Type/CKEditorType.php
@@ -24,6 +24,8 @@ class CKEditorType extends AbstractType
      */
     protected function getFormType()
     {
-        return 'ckeditor';
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Ivory\CKEditorBundle\Form\Type\CKEditorType'
+            : 'ckeditor';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "doctrine/orm": "~2.3",
+        "egeloen/ckeditor-bundle": "^2.5|^3.0|^4.0",
         "phpspec/phpspec": "^2.0",
         "fsi/doctrine-extensions-bundle": "~1.0",
         "fsi/form-extensions-bundle": "1.0.*"

--- a/spec/FSi/Bundle/ResourceRepositoryBundle/Repository/Resource/Type/CKEditorTypeSpec.php
+++ b/spec/FSi/Bundle/ResourceRepositoryBundle/Repository/Resource/Type/CKEditorTypeSpec.php
@@ -37,7 +37,7 @@ class CKEditorTypeSpec extends ObjectBehavior
 
     function it_return_form_builder(FormFactory $factory, FormBuilder $form)
     {
-        $factory->createNamedBuilder('textValue', 'ckeditor', null, array(
+        $factory->createNamedBuilder('textValue', $this->getCKEditorFormType(), null, array(
             'label' => false,
             'required' => false,
         ))->shouldBeCalled()->willReturn($form);
@@ -49,7 +49,7 @@ class CKEditorTypeSpec extends ObjectBehavior
     {
         $this->addConstraint($constraint);
 
-        $factory->createNamedBuilder('textValue', 'ckeditor', null, array(
+        $factory->createNamedBuilder('textValue', $this->getCKEditorFormType(), null, array(
             'label' => false,
             'required' => false,
             'constraints' => array(
@@ -68,7 +68,7 @@ class CKEditorTypeSpec extends ObjectBehavior
             )
         ));
 
-        $factory->createNamedBuilder('textValue', 'ckeditor', null, array(
+        $factory->createNamedBuilder('textValue', $this->getCKEditorFormType(), null, array(
             'label' => false,
             'required' => false,
             'attr' => array(
@@ -77,5 +77,15 @@ class CKEditorTypeSpec extends ObjectBehavior
         ))->shouldBeCalled()->willReturn($form);
 
         $this->getFormBuilder($factory)->shouldReturnAnInstanceOf('Symfony\Component\Form\FormBuilder');
+    }
+
+    /**
+     * @return string
+     */
+    private function getCKEditorFormType()
+    {
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Ivory\CKEditorBundle\Form\Type\CKEditorType'
+            : 'ckeditor';
     }
 }


### PR DESCRIPTION
According to [this](https://github.com/egeloen/IvoryCKEditorBundle/blob/master/DependencyInjection/IvoryCKEditorExtension.php#L43-L47) `ckeditor` alias is only available when `AbstractType::getBlockPrefix` does not exist